### PR TITLE
Remove ../ from a node_modules import

### DIFF
--- a/src/util/execute-steps.ts
+++ b/src/util/execute-steps.ts
@@ -1,4 +1,4 @@
-import chalk from '../../node_modules/chalk';
+import chalk from 'chalk';
 import { IRepo } from '../adapters/base';
 import { IMigrationContext } from '../migration-context';
 import execInRepo from '../util/exec-in-repo';


### PR DESCRIPTION
I'm not sure why this file imports from `../../node_modules/<dependency>` but it's currently breaking my CLI usage when installing with yarn